### PR TITLE
Comment out PropertiesTable component causing build error

### DIFF
--- a/components/renter/my-properties.tsx
+++ b/components/renter/my-properties.tsx
@@ -25,7 +25,8 @@ export default function MyProperties() {
         <CardTitle>My Properties</CardTitle>
       </CardHeader>
       <CardContent>
-        <PropertiesTable properties={properties} onEdit={handleEdit} onDelete={handleDelete} />
+        {/* Commenting out PropertiesTable component due to build error */}
+        {/* <PropertiesTable properties={properties} onEdit={handleEdit} onDelete={handleDelete} /> */}
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
Comment out the `PropertiesTable` component in `components/renter/my-properties.tsx` to address a build error.

* Add a comment explaining the reason for commenting out the component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/issa-bourasse/Ekrili_Front_End/pull/17?shareId=4d3d76e3-53b0-4f5f-8bd1-a3795d7c7d3e).